### PR TITLE
BDOG-994: disable JUnitXml reporter

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,7 @@ val appName = "file-transmission"
 
 lazy val microservice = Project(appName, file("."))
   .enablePlugins(play.sbt.PlayScala, SbtAutoBuildPlugin, SbtGitVersioning, SbtDistributablesPlugin, SbtArtifactory)
+  .disablePlugins(JUnitXmlReportPlugin) //Required to prevent https://github.com/scalatest/scalatest/issues/1427
   .settings(scalaVersion := "2.12.10")
   .settings(PlayKeys.playDefaultPort := 9575)
   .settings(majorVersion := 1)


### PR DESCRIPTION
avoid 'content is not allowed in trailing section' on Jenkins